### PR TITLE
Resolve #2 by adopting the ecma2017 parser

### DIFF
--- a/gourmet_app.js
+++ b/gourmet_app.js
@@ -4,7 +4,7 @@ module.exports = {
     "./partials/browser.js",
     "./partials/commonjs.js",
     "./partials/gourmet_globals.js",
-    "./partials/es6.js",
+    "./partials/es.js",
     "./partials/modules.js",
     "./partials/jsx.js"
   ]

--- a/gourmet_lib.js
+++ b/gourmet_lib.js
@@ -4,7 +4,7 @@ module.exports = {
     "./partials/browser.js",
     "./partials/commonjs.js",
     "./partials/gourmet_globals.js",
-    "./partials/es6.js",
+    "./partials/es.js",
     "./partials/node.js",
     "./partials/jsx.js"
   ]

--- a/node.js
+++ b/node.js
@@ -3,6 +3,6 @@ module.exports = {
     "./partials/base.js",
     "./partials/node.js",
     "./partials/commonjs.js",
-    "./partials/es6.js"
+    "./partials/es.js"
   ]
 };

--- a/partials/es.js
+++ b/partials/es.js
@@ -1,6 +1,6 @@
 module.exports = {
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2017,
     sourceType: "script"
   },
   env: {

--- a/react.js
+++ b/react.js
@@ -4,7 +4,7 @@ module.exports = {
     "./partials/browser.js",
     "./partials/node.js",
     "./partials/commonjs.js",
-    "./partials/es6.js",
+    "./partials/es.js",
     "./partials/jsx.js"
   ]
 };


### PR DESCRIPTION
This is the simplest solution to #2 -- simply updating `es6.js` to use the ECMA 2017 parser. Because the name implied an older version (es6), I also renamed to `es.js` so that the version can change in the future without making filename inaccurate.
This could be overridden in the browser or node partials by specific projects as required by their browser support requirements if they need to disallow ECMA 2017 features.